### PR TITLE
Update README.md with details for whitelisting introspection queries. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Schema = GraphQL::Schema.define do
 end
 </pre>
 
-When using a policy object, you may want to allow [introspection queries](http://graphql.org/learn/introspection/) to skip authorization. A simple way to avoid having to whitelist every introspection type in the `RULES` hash of your policy object is to check the `type` parameter in the guard method: 
+When using a policy object, you may want to allow [introspection queries](http://graphql.org/learn/introspection/) to skip authorization. A simple way to avoid having to whitelist every introspection type in the `RULES` hash of your policy object is to check the `type` parameter in the `guard` method: 
 <pre> 
   def self.guard(type, field)
     <b>type.introspection?</b> || RULES.dig(type, field)

--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ Schema = GraphQL::Schema.define do
 end
 </pre>
 
+When using a policy object, you may want to allow [introspection queries](http://graphql.org/learn/introspection/) to skip authorization. A simple way to avoid having to whitelist every introspection type in the RULES hash of your policy object is to check the <b>type</b> in the guard method: 
+<pre> 
+  def self.guard(type, field)
+    <b>type.introspection?</b> || RULES.dig(type, field)
+  end
+</pre>
+
 ## Priority order
 
 `GraphQL::Guard` will use the policy in the following order of priority:

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Schema = GraphQL::Schema.define do
 end
 </pre>
 
-When using a policy object, you may want to allow [introspection queries](http://graphql.org/learn/introspection/) to skip authorization. A simple way to avoid having to whitelist every introspection type in the RULES hash of your policy object is to check the <b>type</b> in the guard method: 
+When using a policy object, you may want to allow [introspection queries](http://graphql.org/learn/introspection/) to skip authorization. A simple way to avoid having to whitelist every introspection type in the `RULES` hash of your policy object is to check the `type` parameter in the guard method: 
 <pre> 
   def self.guard(type, field)
     <b>type.introspection?</b> || RULES.dig(type, field)


### PR DESCRIPTION
I've tried to keep the changes to a minimum, while also keeping the new section clear. I didn't create a separate section as you suggested, because I thought that the introspection bit makes sense only in the context of using a GraphQLPolicy object (so policy 4), so it seemed natural to append it to the existing section. 