### PR TITLE
Allow inline policies to be used with class-based API of graphql-ruby 1.8

### DIFF
--- a/lib/graphql/guard.rb
+++ b/lib/graphql/guard.rb
@@ -8,6 +8,22 @@ GraphQL::Field.accepts_definitions(guard: GraphQL::Define.assign_metadata_key(:g
 GraphQL::Field.accepts_definitions(mask: GraphQL::Define.assign_metadata_key(:mask))
 
 module GraphQL
+  class Schema
+    class Object
+      accepts_definition :guard
+      accepts_definition :mask
+
+      field_class(
+        Class.new(GraphQL::Schema::Field) {
+          accepts_definition :guard
+          accepts_definition :mask
+        }
+      )
+    end
+  end
+end
+
+module GraphQL
   class Guard
     ANY_FIELD_NAME = :'*'
     DEFAULT_NOT_AUTHORIZED = ->(type, field) { raise NotAuthorizedError.new("#{type}.#{field}") }

--- a/lib/graphql/guard/testing.rb
+++ b/lib/graphql/guard/testing.rb
@@ -33,4 +33,18 @@ module GraphQL
       end
     end
   end
+
+  class Schema
+    class Object
+      def self.field_with_guard(field_name, policy_object = nil)
+        field = fields[field_name]
+        return unless field
+
+        field.to_graphql.clone.tap do |f|
+          f.__policy_object = policy_object
+          f.__guard_type = self.to_graphql
+        end
+      end
+    end
+  end
 end

--- a/spec/fixtures/inline_schema.rb
+++ b/spec/fixtures/inline_schema.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Inline
+  # Schema in legacy-style API
   PostType = GraphQL::ObjectType.define do
     name "Post"
     guard ->(_post, _args, ctx) { ctx[:current_user].admin? }
@@ -30,6 +31,45 @@ module Inline
 
   SchemaWithoutExceptions = GraphQL::Schema.define do
     query QueryType
+    use GraphQL::Guard.new(not_authorized: ->(type, field) {
+      GraphQL::ExecutionError.new("Not authorized to access #{type}.#{field}")
+    })
+  end
+
+  # Schema in class-based API
+  class ClassBasedPost < GraphQL::Schema::Object
+    guard ->(_post, _args, ctx) { ctx[:current_user].admin? }
+    field :id, ID, null: false
+    field :title, String, null: true
+  end
+
+  class ClassBasedQuery < GraphQL::Schema::Object
+    field :posts, [ClassBasedPost], null: false do
+      argument :user_id, ID, required: true
+      guard ->(_obj, args, ctx) { args[:userId] == ctx[:current_user].id }
+    end
+
+    def posts(user_id:)
+      Post.where(user_id: user_id)
+    end
+
+    field :posts_with_mask, [ClassBasedPost], null: false do
+      argument :user_id, ID, required: true
+      mask ->(ctx) { ctx[:current_user].admin? }
+    end
+
+    def posts_with_mask(user_id:)
+      Post.where(user_id: user_id)
+    end
+  end
+
+  class ClassBasedSchema < GraphQL::Schema
+    query ClassBasedQuery
+    use GraphQL::Guard.new
+  end
+
+  class ClassBasedSchemaWithoutExceptions < GraphQL::Schema
+    query ClassBasedQuery
     use GraphQL::Guard.new(not_authorized: ->(type, field) {
       GraphQL::ExecutionError.new("Not authorized to access #{type}.#{field}")
     })

--- a/spec/fixtures/inline_schema.rb
+++ b/spec/fixtures/inline_schema.rb
@@ -11,15 +11,15 @@ module Inline
   QueryType = GraphQL::ObjectType.define do
     name "Query"
     field :posts, !types[!PostType] do
-      argument :user_id, !types.ID
-      guard ->(_obj, args, ctx) { args[:user_id] == ctx[:current_user].id }
-      resolve ->(_obj, args, _ctx) { Post.where(user_id: args[:user_id]) }
+      argument :userId, !types.ID
+      guard ->(_obj, args, ctx) { args[:userId] == ctx[:current_user].id }
+      resolve ->(_obj, args, _ctx) { Post.where(user_id: args[:userId]) }
     end
 
-    field :posts_with_mask, !types[!PostType] do
-      argument :user_id, !types.ID
+    field :postsWithMask, !types[!PostType] do
+      argument :userId, !types.ID
       mask ->(ctx) { ctx[:current_user].admin? }
-      resolve ->(_obj, args, _ctx) { Post.where(user_id: args[:user_id]) }
+      resolve ->(_obj, args, _ctx) { Post.where(user_id: args[:userId]) }
     end
   end
 

--- a/spec/fixtures/policy_object_schema.rb
+++ b/spec/fixtures/policy_object_schema.rb
@@ -10,15 +10,15 @@ module PolicyObject
   QueryType = GraphQL::ObjectType.define do
     name "Query"
     field :posts, !types[!PostType] do
-      argument :user_id, !types.ID
-      resolve ->(_obj, args, _ctx) { Post.where(user_id: args[:user_id]) }
+      argument :userId, !types.ID
+      resolve ->(_obj, args, _ctx) { Post.where(user_id: args[:userId]) }
     end
   end
 
   class GraphqlPolicy
     RULES = {
       QueryType => {
-        posts: ->(_obj, args, ctx) { args[:user_id] == ctx[:current_user].id }
+        posts: ->(_obj, args, ctx) { args[:userId] == ctx[:current_user].id }
       },
       PostType => {
         '*': ->(_post, args, ctx) { ctx[:current_user].admin? }

--- a/spec/graphql/guard_spec.rb
+++ b/spec/graphql/guard_spec.rb
@@ -9,69 +9,163 @@ require 'fixtures/policy_object_schema'
 
 RSpec.describe GraphQL::Guard do
   context 'inline guard' do
-    it 'authorizes to execute a query' do
-      user = User.new(id: '1', role: 'admin')
-      query = "query($userId: ID!) { posts(userId: $userId) { id title } }"
+    context 'with a valid userId and context' do
+      let(:query) { 'query($userId: ID!) { posts(userId: $userId) { id title } }' }
+      let(:user) { User.new(id: '1', role: 'admin') }
+      let(:result) { {'data' => {'posts' => [{'id' => '1', 'title' => 'Post Title'}]}} }
 
-      result = Inline::Schema.execute(query, variables: {'userId' => user.id}, context: {current_user: user})
+      subject { schema.execute(query, variables: {'userId' => user.id}, context: {current_user: user}) }
 
-      expect(result).to eq({"data" => {"posts" => [{"id" => "1", "title" => "Post Title"}]}})
+      context 'and using legacy-style schema' do
+        let(:schema) { Inline::Schema }
+
+        it 'authorizes to execute a query' do
+          expect(subject).to eq(result)
+        end
+      end
+
+      context 'and using class-based schema' do
+        let(:schema) { Inline::ClassBasedSchema }
+
+        it 'authorizes to execute a query' do
+          expect(subject).to eq(result)
+        end
+      end
     end
 
-    it 'does not authorize a field' do
-      user = User.new(id: '1', role: 'admin')
-      query = "query($userId: ID!) { posts(userId: $userId) { id title } }"
+    context 'with sending invalid credential' do
+      let(:query) { 'query($userId: ID!) { posts(userId: $userId) { id title } }' }
+      let(:user) { User.new(id: '1', role: 'admin') }
 
-      expect {
-        Inline::Schema.execute(query, variables: {'userId' => '2'}, context: {current_user: user})
-      }.to raise_error(GraphQL::Guard::NotAuthorizedError, 'Query.posts')
+      subject { schema.execute(query, variables: {'userId' => '2'}, context: {current_user: user}) }
+
+      context 'and using legacy-style schema' do
+        let(:schema) { Inline::Schema }
+
+        it 'does not authorize a field' do
+          expect { subject }.to raise_error(GraphQL::Guard::NotAuthorizedError, 'Query.posts')
+        end
+      end
+
+      context 'and using class-based schema' do
+        let(:schema) { Inline::ClassBasedSchema }
+
+        it 'does not authorize a field' do
+          expect { subject }.to raise_error(GraphQL::Guard::NotAuthorizedError, 'ClassBasedQuery.posts')
+        end
+      end
     end
 
-    it 'does not authorize a field with a policy on the type' do
-      user = User.new(id: '1', role: 'not_admin')
-      query = "query($userId: ID!) { posts(userId: $userId) { id title } }"
+    context 'with sending invalid role' do
+      let(:query) { 'query($userId: ID!) { posts(userId: $userId) { id title } }' }
+      let(:user) { User.new(id: '1', role: 'not_admin') }
 
-      expect {
-        Inline::Schema.execute(query, variables: {'userId' => '1'}, context: {current_user: user})
-      }.to raise_error(GraphQL::Guard::NotAuthorizedError, 'Post.id')
+      subject { schema.execute(query, variables: {'userId' => '1'}, context: {current_user: user}) }
+
+      context 'and using legacy-style schema' do
+        let(:schema) { Inline::Schema }
+
+        it 'does not authorize a field with a policy on the type' do
+          expect { subject }.to raise_error(GraphQL::Guard::NotAuthorizedError, 'Post.id')
+        end
+      end
+
+      context 'and using class-based schema' do
+        let(:schema) { Inline::ClassBasedSchema }
+
+        it 'does not authorize a field with a policy on the type' do
+          expect { subject }.to raise_error(GraphQL::Guard::NotAuthorizedError, 'ClassBasedPost.id')
+        end
+      end
     end
 
-    it 'does not authorize a field and returns an error' do
-      user = User.new(id: '1', role: 'not_admin')
-      query = "query($userId: ID!) { posts(userId: $userId) { id title } }"
+    context 'with sending invalid role to field' do
+      let(:query) { 'query($userId: ID!) { posts(userId: $userId) { id title } }' }
+      let(:user) { User.new(id: '1', role: 'not_admin') }
 
-      result = Inline::SchemaWithoutExceptions.execute(query, variables: {'userId' => '1'}, context: {current_user: user})
+      subject { schema.execute(query, variables: {'userId' => '1'}, context: {current_user: user}) }
 
-      expect(result['errors']).to eq([{
-        "message" => "Not authorized to access Post.id",
-        "locations" => [{"line" => 1, "column" => 48}],
-        "path" => ["posts", 0, "id"]}
-      ])
-      expect(result['data']).to eq(nil)
+      context 'and using legacy-style schema' do
+        let(:schema) { Inline::SchemaWithoutExceptions }
+
+        it 'does not authorize a field and returns an error' do
+          expect(subject['errors']).to eq([{
+            'message' => 'Not authorized to access Post.id',
+            'locations' => [{'line' => 1, 'column' => 48}],
+            'path' => ['posts', 0, 'id']}
+          ])
+          expect(subject['data']).to eq(nil)
+        end
+      end
+
+      context 'and using class-based schema' do
+        let(:schema) { Inline::ClassBasedSchemaWithoutExceptions }
+
+        it 'does not authorize a field and returns an error' do
+          expect(subject['errors']).to eq([{
+            'message' => 'Not authorized to access ClassBasedPost.id',
+            'locations' => [{'line' => 1, 'column' => 48}],
+            'path' => ['posts', 0, 'id']}
+          ])
+          expect(subject['data']).to eq(nil)
+        end
+      end
     end
   end
 
   context 'inline mask' do
-    it 'allows to query a field' do
-      user = User.new(id: '1', role: 'admin')
-      query = "query($userId: ID!) { postsWithMask(userId: $userId) { id } }"
+    context 'with admin role user' do
+      let(:query) { 'query($userId: ID!) { postsWithMask(userId: $userId) { id } }' }
+      let(:user) { User.new(id: '1', role: 'admin') }
 
-      result = Inline::Schema.execute(query, variables: {'userId' => user.id}, context: {current_user: user})
+      subject { schema.execute(query, variables: {'userId' => user.id}, context: {current_user: user}) }
 
-      expect(result.to_h).to eq({"data" => {"postsWithMask" => [{"id" => "1"}]}})
+      context 'and using legacy-style schema' do
+        let(:schema) { Inline::Schema }
+
+        it 'allows to query a field' do
+          expect(subject.to_h).to eq({'data' => {'postsWithMask' => [{'id' => '1'}]}})
+        end
+      end
+
+      context 'and using class-based schema' do
+        let(:schema) { Inline::ClassBasedSchema }
+
+        it 'allows to query a field' do
+          expect(subject.to_h).to eq({'data' => {'postsWithMask' => [{'id' => '1'}]}})
+        end
+      end
     end
 
-    it 'hides a field' do
-      user = User.new(id: '1', role: 'not_admin')
-      query = "query($userId: ID!) { postsWithMask(userId: $userId) { id } }"
+    context 'with not admin role user' do
+      let(:query) { 'query($userId: ID!) { postsWithMask(userId: $userId) { id } }' }
+      let(:user) { User.new(id: '1', role: 'not_admin') }
 
-      result = Inline::Schema.execute(query, variables: {'userId' => user.id}, context: {current_user: user})
+      subject { schema.execute(query, variables: {'userId' => user.id}, context: {current_user: user}) }
 
-      expect(result['errors']).to include({
-        "message" => "Field 'postsWithMask' doesn't exist on type 'Query'",
-        "locations" => [{"line" => 1, "column" => 23}],
-        "fields" => ["query", "postsWithMask"]
-      })
+      context 'and using legacy-style schema' do
+        let(:schema) { Inline::Schema }
+
+        it 'hides a field' do
+          expect(subject['errors']).to include({
+            'message' => %Q(Field 'postsWithMask' doesn't exist on type 'Query'),
+            'locations' => [{'line' => 1, 'column' => 23}],
+            'fields' => ['query', 'postsWithMask']
+          })
+        end
+      end
+
+      context 'and using class-based schema' do
+        let(:schema) { Inline::ClassBasedSchema }
+
+        it 'hides a field' do
+          expect(subject['errors']).to include({
+            'message' => %Q(Field 'postsWithMask' doesn't exist on type 'ClassBasedQuery'),
+            'locations' => [{'line' => 1, 'column' => 23}],
+            'fields' => ['query', 'postsWithMask']
+          })
+        end
+      end
     end
   end
 

--- a/spec/graphql/guard_spec.rb
+++ b/spec/graphql/guard_spec.rb
@@ -11,40 +11,40 @@ RSpec.describe GraphQL::Guard do
   context 'inline guard' do
     it 'authorizes to execute a query' do
       user = User.new(id: '1', role: 'admin')
-      query = "query($user_id: ID!) { posts(user_id: $user_id) { id title } }"
+      query = "query($userId: ID!) { posts(userId: $userId) { id title } }"
 
-      result = Inline::Schema.execute(query, variables: {'user_id' => user.id}, context: {current_user: user})
+      result = Inline::Schema.execute(query, variables: {'userId' => user.id}, context: {current_user: user})
 
       expect(result).to eq({"data" => {"posts" => [{"id" => "1", "title" => "Post Title"}]}})
     end
 
     it 'does not authorize a field' do
       user = User.new(id: '1', role: 'admin')
-      query = "query($user_id: ID!) { posts(user_id: $user_id) { id title } }"
+      query = "query($userId: ID!) { posts(userId: $userId) { id title } }"
 
       expect {
-        Inline::Schema.execute(query, variables: {'user_id' => '2'}, context: {current_user: user})
+        Inline::Schema.execute(query, variables: {'userId' => '2'}, context: {current_user: user})
       }.to raise_error(GraphQL::Guard::NotAuthorizedError, 'Query.posts')
     end
 
     it 'does not authorize a field with a policy on the type' do
       user = User.new(id: '1', role: 'not_admin')
-      query = "query($user_id: ID!) { posts(user_id: $user_id) { id title } }"
+      query = "query($userId: ID!) { posts(userId: $userId) { id title } }"
 
       expect {
-        Inline::Schema.execute(query, variables: {'user_id' => '1'}, context: {current_user: user})
+        Inline::Schema.execute(query, variables: {'userId' => '1'}, context: {current_user: user})
       }.to raise_error(GraphQL::Guard::NotAuthorizedError, 'Post.id')
     end
 
     it 'does not authorize a field and returns an error' do
       user = User.new(id: '1', role: 'not_admin')
-      query = "query($user_id: ID!) { posts(user_id: $user_id) { id title } }"
+      query = "query($userId: ID!) { posts(userId: $userId) { id title } }"
 
-      result = Inline::SchemaWithoutExceptions.execute(query, variables: {'user_id' => '1'}, context: {current_user: user})
+      result = Inline::SchemaWithoutExceptions.execute(query, variables: {'userId' => '1'}, context: {current_user: user})
 
       expect(result['errors']).to eq([{
         "message" => "Not authorized to access Post.id",
-        "locations" => [{"line" => 1, "column" => 51}],
+        "locations" => [{"line" => 1, "column" => 48}],
         "path" => ["posts", 0, "id"]}
       ])
       expect(result['data']).to eq(nil)
@@ -54,23 +54,23 @@ RSpec.describe GraphQL::Guard do
   context 'inline mask' do
     it 'allows to query a field' do
       user = User.new(id: '1', role: 'admin')
-      query = "query($user_id: ID!) { posts_with_mask(user_id: $user_id) { id } }"
+      query = "query($userId: ID!) { postsWithMask(userId: $userId) { id } }"
 
-      result = Inline::Schema.execute(query, variables: {'user_id' => user.id}, context: {current_user: user})
+      result = Inline::Schema.execute(query, variables: {'userId' => user.id}, context: {current_user: user})
 
-      expect(result.to_h).to eq({"data" => {"posts_with_mask" => [{"id" => "1"}]}})
+      expect(result.to_h).to eq({"data" => {"postsWithMask" => [{"id" => "1"}]}})
     end
 
     it 'hides a field' do
       user = User.new(id: '1', role: 'not_admin')
-      query = "query($user_id: ID!) { posts_with_mask(user_id: $user_id) { id } }"
+      query = "query($userId: ID!) { postsWithMask(userId: $userId) { id } }"
 
-      result = Inline::Schema.execute(query, variables: {'user_id' => user.id}, context: {current_user: user})
+      result = Inline::Schema.execute(query, variables: {'userId' => user.id}, context: {current_user: user})
 
       expect(result['errors']).to include({
-        "message" => "Field 'posts_with_mask' doesn't exist on type 'Query'",
-        "locations" => [{"line" => 1, "column" => 24}],
-        "fields" => ["query", "posts_with_mask"]
+        "message" => "Field 'postsWithMask' doesn't exist on type 'Query'",
+        "locations" => [{"line" => 1, "column" => 23}],
+        "fields" => ["query", "postsWithMask"]
       })
     end
   end
@@ -78,28 +78,28 @@ RSpec.describe GraphQL::Guard do
   context 'policy object guard' do
     it 'authorizes to execute a query' do
       user = User.new(id: '1', role: 'admin')
-      query = "query($user_id: ID!) { posts(user_id: $user_id) { id title } }"
+      query = "query($userId: ID!) { posts(userId: $userId) { id title } }"
 
-      result = PolicyObject::Schema.execute(query, variables: {'user_id' => user.id}, context: {current_user: user})
+      result = PolicyObject::Schema.execute(query, variables: {'userId' => user.id}, context: {current_user: user})
 
       expect(result).to eq({"data" => {"posts" => [{"id" => "1", "title" => "Post Title"}]}})
     end
 
     it 'does not authorize a field' do
       user = User.new(id: '1', role: 'admin')
-      query = "query($user_id: ID!) { posts(user_id: $user_id) { id title } }"
+      query = "query($userId: ID!) { posts(userId: $userId) { id title } }"
 
       expect {
-        PolicyObject::Schema.execute(query, variables: {'user_id' => '2'}, context: {current_user: user})
+        PolicyObject::Schema.execute(query, variables: {'userId' => '2'}, context: {current_user: user})
       }.to raise_error(GraphQL::Guard::NotAuthorizedError, 'Query.posts')
     end
 
     it 'does not authorize a field with a policy on the type' do
       user = User.new(id: '1', role: 'not_admin')
-      query = "query($user_id: ID!) { posts(user_id: $user_id) { id title } }"
+      query = "query($userId: ID!) { posts(userId: $userId) { id title } }"
 
       expect {
-        PolicyObject::Schema.execute(query, variables: {'user_id' => '1'}, context: {current_user: user})
+        PolicyObject::Schema.execute(query, variables: {'userId' => '1'}, context: {current_user: user})
       }.to raise_error(GraphQL::Guard::NotAuthorizedError, 'Post.id')
     end
   end

--- a/spec/graphql/testing_spec.rb
+++ b/spec/graphql/testing_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe GraphQL::Guard do
       posts_field = Inline::QueryType.field_with_guard('posts')
       user = User.new(id: '1', role: 'admin')
 
-      result = posts_field.guard(nil, {user_id: user.id}, {current_user: user})
+      result = posts_field.guard(nil, {userId: user.id}, {current_user: user})
 
       expect(result).to eq(true)
     end
@@ -24,7 +24,7 @@ RSpec.describe GraphQL::Guard do
       posts_field = Inline::QueryType.field_with_guard('posts')
       user = User.new(id: '1', role: 'admin')
 
-      result = posts_field.guard(nil, {user_id: '2'}, {current_user: user})
+      result = posts_field.guard(nil, {userId: '2'}, {current_user: user})
 
       expect(result).to eq(false)
     end
@@ -44,7 +44,7 @@ RSpec.describe GraphQL::Guard do
       posts_field = PolicyObject::QueryType.field_with_guard('posts', PolicyObject::GraphqlPolicy)
       user = User.new(id: '1', role: 'admin')
 
-      result = posts_field.guard(nil, {user_id: user.id}, {current_user: user})
+      result = posts_field.guard(nil, {userId: user.id}, {current_user: user})
 
       expect(result).to eq(true)
     end
@@ -54,7 +54,7 @@ RSpec.describe GraphQL::Guard do
       user = User.new(id: '1', role: 'admin')
 
       expect {
-        posts_field.guard(nil, {user_id: user.id}, {current_user: user})
+        posts_field.guard(nil, {userId: user.id}, {current_user: user})
       }.to raise_error(GraphQL::Field::NoGuardError, "Guard lambda does not exist for Query.posts")
     end
 
@@ -63,7 +63,7 @@ RSpec.describe GraphQL::Guard do
       user = User.new(id: '1', role: 'admin')
 
       expect {
-        posts_field.guard(nil, {user_id: user.id}, {current_user: user})
+        posts_field.guard(nil, {userId: user.id}, {current_user: user})
       }.to raise_error(GraphQL::Field::NoGuardError, "Get your field by calling: Type.field_with_guard('posts')")
     end
 
@@ -71,7 +71,7 @@ RSpec.describe GraphQL::Guard do
       posts_field = PolicyObject::QueryType.field_with_guard('posts', PolicyObject::GraphqlPolicy)
       user = User.new(id: '1', role: 'admin')
 
-      result = posts_field.guard(nil, {user_id: '2'}, {current_user: user})
+      result = posts_field.guard(nil, {userId: '2'}, {current_user: user})
 
       expect(result).to eq(false)
     end


### PR DESCRIPTION
Partially fixes the problem discussed in #15

This PR allows inline guard policies to be used with class-based API of graphql-ruby 1.8.

In class-based API of graphql-ruby 1.8, `GraphQL::Schema::Object` and `GraphQL::Schema::Field` are used as base classes for class-based schema. In order to use class-based API with graphql-guard and to keep interface compatibility, these classes need to accept metadata `guard` and `mask`. `accepts_definition` is available for these cases.

http://graphql-ruby.org/api-doc/1.8.2/GraphQL/Schema/Member/AcceptsDefinition

Also in order to keep `GraphQL::Guard::Testing` compatibility, `GraphQL::Schema::Object` needs to have the class method `.field_with_guard` where these methods are utilized:

- `fields`
  - gets fields of a class-based object
- `to_graphql`
  - converts a class-based object like `GraphQL::Schema::Object` to corresponding legacy-style object like `GraphQL::ObjectType`
  - [GraphQL - Extending the GraphQL-Ruby Type Definition System](http://graphql-ruby.org/type_definitions/extensions)

When class-based API is used, the testing method `GraphQL::Field#guard` uses objects converted by `to_graphql`.

These changes are tested by graphql-ruby 1.8.2.
